### PR TITLE
[R4R]: delete closed swap and optimize gas consumption

### DIFF
--- a/ethereum/contracts/ERC20AtomicSwapper.sol
+++ b/ethereum/contracts/ERC20AtomicSwapper.sol
@@ -106,7 +106,7 @@ contract ERC20AtomicSwapper {
             timestamp: _timestamp,
             sender: msg.sender,
             receiverAddr: _receiverAddr
-            });
+        });
 
         swaps[_secretHashLock] = swap;
         swapStates[_secretHashLock] = States.OPEN;
@@ -162,11 +162,11 @@ contract ERC20AtomicSwapper {
     function queryOpenSwap(bytes32 _secretHashLock) external view returns(uint64 _timestamp, uint256 _expireHeight, uint256 _outAmount, address _sender, address _receiver) {
         Swap memory swap = swaps[_secretHashLock];
         return (
-        swap.timestamp,
-        swap.expireHeight,
-        swap.outAmount,
-        swap.sender,
-        swap.receiverAddr
+            swap.timestamp,
+            swap.expireHeight,
+            swap.outAmount,
+            swap.sender,
+            swap.receiverAddr
         );
     }
 

--- a/ethereum/contracts/ERC20AtomicSwapper.sol
+++ b/ethereum/contracts/ERC20AtomicSwapper.sol
@@ -27,9 +27,9 @@ contract ERC20AtomicSwapper {
     }
 
     // Events
-    event SwapInit(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _secretHashLock, uint64 _timestamp, bytes20 _bep2Addr, uint256 _expireHeight, uint256 _outAmount, uint256 _bep2Amount);
-    event SwapExpire(address indexed _msgSender, address indexed _swapSender, bytes32 indexed _secretHashLock);
-    event SwapComplete(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _secretHashLock, bytes32 _secretKey);
+    event HTLTInit(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _secretHashLock, uint64 _timestamp, bytes20 _bep2Addr, uint256 _expireHeight, uint256 _outAmount, uint256 _bep2Amount);
+    event HTLTExpire(address indexed _msgSender, address indexed _swapSender, bytes32 indexed _secretHashLock);
+    event HTLTComplete(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _secretHashLock, bytes32 _secretKey);
 
     // Storage
     mapping (bytes32 => Swap) private swaps;
@@ -74,27 +74,27 @@ contract ERC20AtomicSwapper {
         ERC20ContractAddr = _erc20Contract;
     }
 
-    /// @notice Initiates an atomic swap.
+    /// @notice hashTimerLockedTransfer locks asset to contract address and create an atomic swap.
     ///
     /// @param _secretHashLock The hash of the secret key and timestamp
     /// @param _timestamp Counted by second
-    /// @param _timelock The number of blocks to wait before the asset can be returned to sender
+    /// @param _heightSpan The number of blocks to wait before the asset can be returned to sender
     /// @param _receiverAddr The ethereum address of the swap counterpart.
     /// @param _bep2Addr The receiver address on Binance Chain
     /// @param _outAmount ERC20 asset to swap out.
     /// @param _bep2Amount BEP2 asset to swap in.
-    function initiate(
+    function hashTimerLockedTransfer(
         bytes32 _secretHashLock,
         uint64  _timestamp,
-        uint256 _timelock,
+        uint256 _heightSpan,
         address _receiverAddr,
         bytes20 _bep2Addr,
         uint256 _outAmount,
         uint256 _bep2Amount
     ) external onlyInvalidSwaps(_secretHashLock) returns (bool) {
         // Assume average block time interval is 10 second
-        // The timelock period should be more than 10 minutes and less than one week
-        require(_timelock >= 60 && _timelock <= 60480, "_timelock should be in [60, 60480]");
+        // The heightSpan period should be more than 10 minutes and less than one week
+        require(_heightSpan >= 60 && _heightSpan <= 60480, "_heightSpan should be in [60, 60480]");
         require(_receiverAddr != address(0), "_receiverAddr should not be zero");
         require(_timestamp > now -7200 && _timestamp < now + 3600, "The timestamp should not be one hour ahead or two hour behind current time");
         // Transfer ERC20 token to the swap contract
@@ -102,7 +102,7 @@ contract ERC20AtomicSwapper {
         // Store the details of the swap.
         Swap memory swap = Swap({
             outAmount: _outAmount,
-            expireHeight: _timelock + block.number,
+            expireHeight: _heightSpan + block.number,
             timestamp: _timestamp,
             sender: msg.sender,
             receiverAddr: _receiverAddr
@@ -112,15 +112,15 @@ contract ERC20AtomicSwapper {
         swapStates[_secretHashLock] = States.OPEN;
 
         // Emit initialization event
-        emit SwapInit(msg.sender, _receiverAddr, _secretHashLock, _timestamp, _bep2Addr, swap.expireHeight, _outAmount, _bep2Amount);
+        emit HTLTInit(msg.sender, _receiverAddr, _secretHashLock, _timestamp, _bep2Addr, swap.expireHeight, _outAmount, _bep2Amount);
         return true;
     }
 
-    /// @notice Claims an atomic swap.
+    /// @notice claimHashTimerLockedTransfer claim the previously locked asset.
     ///
     /// @param _secretHashLock The hash of secretKey and timestamp
     /// @param _secretKey The secret of the atomic swap.
-    function claim(bytes32 _secretHashLock, bytes32 _secretKey) external onlyOpenSwaps(_secretHashLock) onlyBeforeExpireHeight(_secretHashLock) onlyWithSecretKey(_secretHashLock, _secretKey) returns (bool) {
+    function claimHashTimerLockedTransfer(bytes32 _secretHashLock, bytes32 _secretKey) external onlyOpenSwaps(_secretHashLock) onlyBeforeExpireHeight(_secretHashLock) onlyWithSecretKey(_secretHashLock, _secretKey) returns (bool) {
         // Complete the swap.
         swapStates[_secretHashLock] = States.COMPLETED;
 
@@ -132,15 +132,15 @@ contract ERC20AtomicSwapper {
         delete swaps[_secretHashLock];
 
         // Emit completion event
-        emit SwapComplete(msg.sender, receiverAddr, _secretHashLock, _secretKey);
+        emit HTLTComplete(msg.sender, receiverAddr, _secretHashLock, _secretKey);
 
         return true;
     }
 
-    /// @notice Refunds an atomic swap.
+    /// @notice refundHashTimerLockedTransfer refund the previously locked asset.
     ///
     /// @param _secretHashLock The hash of secretKey and timestamp
-    function refund(bytes32 _secretHashLock) external onlyOpenSwaps(_secretHashLock) onlyAfterExpireHeight(_secretHashLock) returns (bool) {
+    function refundHashTimerLockedTransfer(bytes32 _secretHashLock) external onlyOpenSwaps(_secretHashLock) onlyAfterExpireHeight(_secretHashLock) returns (bool) {
         // Expire the swap.
         swapStates[_secretHashLock] = States.EXPIRED;
 
@@ -151,7 +151,7 @@ contract ERC20AtomicSwapper {
         // delete closed swap
         delete swaps[_secretHashLock];
         // Emit expire event
-        emit SwapExpire(msg.sender, swapSender, _secretHashLock);
+        emit HTLTExpire(msg.sender, swapSender, _secretHashLock);
 
         return true;
     }
@@ -170,10 +170,10 @@ contract ERC20AtomicSwapper {
         );
     }
 
-    /// @notice Checks whether a _secretHashLock is initializable or not.
+    /// @notice Checks whether a _secretHashLock can be used to create a hash lock or not.
     ///
     /// @param _secretHashLock The hash of secretKey and timestamp
-    function initializable(bytes32 _secretHashLock) external view returns (bool) {
+    function hashLockable(bytes32 _secretHashLock) external view returns (bool) {
         return (swapStates[_secretHashLock] == States.INVALID);
     }
 

--- a/ethereum/contracts/ERC20AtomicSwapper.sol
+++ b/ethereum/contracts/ERC20AtomicSwapper.sol
@@ -124,13 +124,10 @@ contract ERC20AtomicSwapper {
         // Complete the swap.
         swapStates[_secretHashLock] = States.COMPLETED;
 
-        Swap memory swap = swaps[_secretHashLock];
-        address receiverAddr = swap.receiverAddr;
-        uint256 outAmount = swap.outAmount;
-
         // Pay erc20 token to receiver
-        require(ERC20(ERC20ContractAddr).transfer(receiverAddr, outAmount), "Failed to transfer locked asset to receiver address");
+        require(ERC20(ERC20ContractAddr).transfer(swaps[_secretHashLock].receiverAddr, swaps[_secretHashLock].outAmount), "Failed to transfer locked asset to receiver");
 
+        address receiverAddr = swaps[_secretHashLock].receiverAddr;
         // delete closed swap
         delete swaps[_secretHashLock];
 
@@ -147,17 +144,14 @@ contract ERC20AtomicSwapper {
         // Expire the swap.
         swapStates[_secretHashLock] = States.EXPIRED;
 
-        Swap memory swap = swaps[_secretHashLock];
-        address sender = swap.sender;
-        uint256 outAmount = swap.outAmount;
-
         // refund erc20 token to swap creator
-        require(ERC20(ERC20ContractAddr).transfer(sender, outAmount), "Failed to transfer locked asset to swap creator");
+        require(ERC20(ERC20ContractAddr).transfer(swaps[_secretHashLock].sender, swaps[_secretHashLock].outAmount), "Failed to transfer locked asset back to swap creator");
 
+        address swapSender = swaps[_secretHashLock].sender;
         // delete closed swap
         delete swaps[_secretHashLock];
         // Emit expire event
-        emit SwapExpire(msg.sender, sender, _secretHashLock);
+        emit SwapExpire(msg.sender, swapSender, _secretHashLock);
 
         return true;
     }

--- a/ethereum/contracts/ERC20AtomicSwapper.sol
+++ b/ethereum/contracts/ERC20AtomicSwapper.sol
@@ -12,16 +12,11 @@ interface ERC20 {
 contract ERC20AtomicSwapper {
 
     struct Swap {
-        uint256 erc20Amount;
-        uint256 bep2Amount;
-
+        uint256 outAmount;
         uint256 expireHeight;
-        bytes32 secretKey;
         uint64  timestamp;
-
         address sender;
         address receiverAddr;
-        bytes20 bep2Addr;
     }
 
     enum States {
@@ -32,17 +27,15 @@ contract ERC20AtomicSwapper {
     }
 
     // Events
-    event SwapInit(address indexed _msgSender, address indexed _receiverAddr, bytes20 _bep2Addr, uint256 _index, bytes32 _secretHashLock, uint64 _timestamp, uint256 _expireHeight, uint256 _erc20Amount, uint256 _bep2Amount);
-    event SwapExpire(address indexed _msgSender, address indexed _swapSender, bytes32 _secretHashLock);
-    event SwapComplete(address indexed _msgSender, address indexed _receiverAddr, bytes32 _secretHashLock, bytes32 _secretKey);
+    event SwapInit(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _secretHashLock, uint64 _timestamp, bytes20 _bep2Addr, uint256 _expireHeight, uint256 _outAmount, uint256 _bep2Amount);
+    event SwapExpire(address indexed _msgSender, address indexed _swapSender, bytes32 indexed _secretHashLock);
+    event SwapComplete(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _secretHashLock, bytes32 _secretKey);
 
     // Storage
     mapping (bytes32 => Swap) private swaps;
     mapping (bytes32 => States) private swapStates;
-    mapping (uint256 => bytes32) private indexToSecretHashLock;
 
     address public ERC20ContractAddr;
-    uint256 public index;
 
     /// @notice Throws if the swap is not invalid (i.e. has already been used)
     modifier onlyInvalidSwaps(bytes32 _secretHashLock) {
@@ -79,7 +72,6 @@ contract ERC20AtomicSwapper {
     /// @param _erc20Contract The ERC20 contract address
     constructor(address _erc20Contract) public {
         ERC20ContractAddr = _erc20Contract;
-        index = 0;
     }
 
     /// @notice Initiates an atomic swap.
@@ -89,7 +81,7 @@ contract ERC20AtomicSwapper {
     /// @param _timelock The number of blocks to wait before the asset can be returned to sender
     /// @param _receiverAddr The ethereum address of the swap counterpart.
     /// @param _bep2Addr The receiver address on Binance Chain
-    /// @param _erc20Amount ERC20 asset to swap out.
+    /// @param _outAmount ERC20 asset to swap out.
     /// @param _bep2Amount BEP2 asset to swap in.
     function initiate(
         bytes32 _secretHashLock,
@@ -97,36 +89,30 @@ contract ERC20AtomicSwapper {
         uint256 _timelock,
         address _receiverAddr,
         bytes20 _bep2Addr,
-        uint256 _erc20Amount,
+        uint256 _outAmount,
         uint256 _bep2Amount
     ) external onlyInvalidSwaps(_secretHashLock) returns (bool) {
-        // Assume average block time interval is 15 second
+        // Assume average block time interval is 10 second
         // The timelock period should be more than 10 minutes and less than one week
-        require(_timelock >= 40 && _timelock <= 40320, "_timelock should be in [40, 40320]");
+        require(_timelock >= 60 && _timelock <= 60480, "_timelock should be in [60, 60480]");
         require(_receiverAddr != address(0), "_receiverAddr should not be zero");
-        require(_timestamp > now - 7200 && _timestamp < now + 3600, "The timestamp should not be one hour ahead or two hour behind current time");
+        require(_timestamp > now -7200 && _timestamp < now + 3600, "The timestamp should not be one hour ahead or two hour behind current time");
         // Transfer ERC20 token to the swap contract
-        require(ERC20(ERC20ContractAddr).transferFrom(msg.sender, address(this), _erc20Amount), "failed to transfer client asset to swap contract address");
+        require(ERC20(ERC20ContractAddr).transferFrom(msg.sender, address(this), _outAmount), "failed to transfer client asset to swap contract address");
         // Store the details of the swap.
         Swap memory swap = Swap({
-            erc20Amount: _erc20Amount,
-            bep2Amount: _bep2Amount,
+            outAmount: _outAmount,
             expireHeight: _timelock + block.number,
-            secretKey: 0x0,
             timestamp: _timestamp,
             sender: msg.sender,
-            receiverAddr: _receiverAddr,
-            bep2Addr: _bep2Addr
+            receiverAddr: _receiverAddr
             });
-        uint256 curIndex = index;
 
         swaps[_secretHashLock] = swap;
         swapStates[_secretHashLock] = States.OPEN;
-        indexToSecretHashLock[curIndex] = _secretHashLock;
-        index = index + 1;
 
         // Emit initialization event
-        emit SwapInit(msg.sender, _receiverAddr, _bep2Addr, curIndex,  _secretHashLock, _timestamp, swap.expireHeight, _erc20Amount, _bep2Amount);
+        emit SwapInit(msg.sender, _receiverAddr, _secretHashLock, _timestamp, _bep2Addr, swap.expireHeight, _outAmount, _bep2Amount);
         return true;
     }
 
@@ -134,16 +120,22 @@ contract ERC20AtomicSwapper {
     ///
     /// @param _secretHashLock The hash of secretKey and timestamp
     /// @param _secretKey The secret of the atomic swap.
-    function claim(bytes32 _secretHashLock, bytes32 _secretKey) external onlyBeforeExpireHeight(_secretHashLock) onlyOpenSwaps(_secretHashLock) onlyWithSecretKey(_secretHashLock, _secretKey) returns (bool) {
+    function claim(bytes32 _secretHashLock, bytes32 _secretKey) external onlyOpenSwaps(_secretHashLock) onlyBeforeExpireHeight(_secretHashLock) onlyWithSecretKey(_secretHashLock, _secretKey) returns (bool) {
         // Complete the swap.
-        swaps[_secretHashLock].secretKey = _secretKey;
         swapStates[_secretHashLock] = States.COMPLETED;
 
+        Swap memory swap = swaps[_secretHashLock];
+        address receiverAddr = swap.receiverAddr;
+        uint256 outAmount = swap.outAmount;
+
         // Pay erc20 token to receiver
-        require(ERC20(ERC20ContractAddr).transfer(swaps[_secretHashLock].receiverAddr, swaps[_secretHashLock].erc20Amount), "Failed to transfer locked asset to receiver address");
+        require(ERC20(ERC20ContractAddr).transfer(receiverAddr, outAmount), "Failed to transfer locked asset to receiver address");
+
+        // delete closed swap
+        delete swaps[_secretHashLock];
 
         // Emit completion event
-        emit SwapComplete(msg.sender, swaps[_secretHashLock].receiverAddr, _secretHashLock, _secretKey);
+        emit SwapComplete(msg.sender, receiverAddr, _secretHashLock, _secretKey);
 
         return true;
     }
@@ -155,11 +147,17 @@ contract ERC20AtomicSwapper {
         // Expire the swap.
         swapStates[_secretHashLock] = States.EXPIRED;
 
-        // refund erc20 token to swap creator
-        require(ERC20(ERC20ContractAddr).transfer(swaps[_secretHashLock].sender, swaps[_secretHashLock].erc20Amount), "Failed to transfer locked asset to swap creator");
+        Swap memory swap = swaps[_secretHashLock];
+        address sender = swap.sender;
+        uint256 outAmount = swap.outAmount;
 
+        // refund erc20 token to swap creator
+        require(ERC20(ERC20ContractAddr).transfer(sender, outAmount), "Failed to transfer locked asset to swap creator");
+
+        // delete closed swap
+        delete swaps[_secretHashLock];
         // Emit expire event
-        emit SwapExpire(msg.sender, swaps[_secretHashLock].sender, _secretHashLock);
+        emit SwapExpire(msg.sender, sender, _secretHashLock);
 
         return true;
     }
@@ -167,40 +165,14 @@ contract ERC20AtomicSwapper {
     /// @notice query an atomic swap by secretHashLock
     ///
     /// @param _secretHashLock The hash of secretKey and timestamp
-    function querySwapByHashLock(bytes32 _secretHashLock) external view returns(uint64 _timestamp, uint256 _expireHeight, uint256 _erc20Amount, uint256 _bep2Amount, address _sender, address _receiver, bytes20 _bep2Addr, bytes32 _secretKey, States _status) {
+    function queryOpenSwap(bytes32 _secretHashLock) external view returns(uint64 _timestamp, uint256 _expireHeight, uint256 _outAmount, address _sender, address _receiver) {
         Swap memory swap = swaps[_secretHashLock];
-        States status = swapStates[_secretHashLock];
         return (
-            swap.timestamp,
-            swap.expireHeight,
-            swap.erc20Amount,
-            swap.bep2Amount,
-            swap.sender,
-            swap.receiverAddr,
-            swap.bep2Addr,
-            swap.secretKey,
-            status
-        );
-    }
-
-    /// @notice query an atomic swap by swap index
-    ///
-    /// @param _index The swap index
-    function querySwapByIndex(uint256 _index) external view returns (bytes32 _secretHashLock, uint64 _timestamp, uint256 _expireHeight, uint256 _erc20Amount, uint256 _bep2Amount, address _sender, address _receiver, bytes20 _bep2Addr, bytes32 _secretKey, States _status) {
-        bytes32 secretHashLock = indexToSecretHashLock[_index];
-        Swap memory swap = swaps[secretHashLock];
-        States status = swapStates[secretHashLock];
-        return (
-            secretHashLock,
-            swap.timestamp,
-            swap.expireHeight,
-            swap.erc20Amount,
-            swap.bep2Amount,
-            swap.sender,
-            swap.receiverAddr,
-            swap.bep2Addr,
-            swap.secretKey,
-            status
+        swap.timestamp,
+        swap.expireHeight,
+        swap.outAmount,
+        swap.sender,
+        swap.receiverAddr
         );
     }
 

--- a/ethereum/contracts/ETHAtomicSwapper.sol
+++ b/ethereum/contracts/ETHAtomicSwapper.sol
@@ -86,7 +86,7 @@ contract ETHAtomicSwapper {
             timestamp: _timestamp,
             sender: msg.sender,
             receiverAddr: _receiverAddr
-            });
+        });
 
         swaps[_secretHashLock] = swap;
         swapStates[_secretHashLock] = States.OPEN;
@@ -145,11 +145,11 @@ contract ETHAtomicSwapper {
     function queryOpenSwap(bytes32 _secretHashLock) external view returns(uint64 _timestamp, uint256 _expireHeight, uint256 _outAmount, address _sender, address _receiver) {
         Swap memory swap = swaps[_secretHashLock];
         return (
-        swap.timestamp,
-        swap.expireHeight,
-        swap.outAmount,
-        swap.sender,
-        swap.receiverAddr
+            swap.timestamp,
+            swap.expireHeight,
+            swap.outAmount,
+            swap.sender,
+            swap.receiverAddr
         );
     }
 

--- a/ethereum/test/ERC20AtomicSwapTest.js
+++ b/ethereum/test/ERC20AtomicSwapTest.js
@@ -100,13 +100,13 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         const erc20Amount = 100000000;
         const bep2Amount = 100000000;
 
-        var initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, true);
+        var hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, true);
 
         await bnbInstance.approve(ERC20AtomicSwapper.address, erc20Amount, { from: swapA });
-        let initiateTx = await swapInstance.initiate(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, erc20Amount, bep2Amount, { from: swapA });
+        let initiateTx = await swapInstance.hashTimerLockedTransfer(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, erc20Amount, bep2Amount, { from: swapA });
         //SwapInit event should be emitted
-        truffleAssert.eventEmitted(initiateTx, 'SwapInit', (ev) => {
+        truffleAssert.eventEmitted(initiateTx, 'HTLTInit', (ev) => {
             return ev._msgSender === swapA &&
                 ev._receiverAddr === swapB &&
                 ev._bep2Addr === bep2Addr &&
@@ -126,8 +126,8 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         assert.equal(timestamp, swap._timestamp);
         assert.equal(swapA, swap._sender);
 
-        initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, false);
+        hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, false);
         var claimable = (await swapInstance.claimable.call(secretHashLock)).valueOf();
         assert.equal(claimable, true);
         var refundable = (await swapInstance.refundable.call(secretHashLock)).valueOf();
@@ -137,9 +137,9 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         assert.equal(Number(balanceOfSwapB.toString()), 0);
 
         // Anyone can call claim and the token will be paid to swapB address
-        let claimTx = await swapInstance.claim(secretHashLock, secretKey, { from: accounts[6] });
+        let claimTx = await swapInstance.claimHashTimerLockedTransfer(secretHashLock, secretKey, { from: accounts[6] });
         //SwapComplete n event should be emitted
-        truffleAssert.eventEmitted(claimTx, 'SwapComplete', (ev) => {
+        truffleAssert.eventEmitted(claimTx, 'HTLTComplete', (ev) => {
             return ev._msgSender === accounts[6] && ev._receiverAddr === swapB && ev._secretHashLock === secretHashLock && ev._secretKey === secretKey;
         });
         console.log("claimTx gasUsed: ", claimTx.receipt.gasUsed);
@@ -171,13 +171,13 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         const erc20Amount = 100000000;
         const bep2Amount = 100000000;
 
-        var initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, true);
+        var hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, true);
 
         await bnbInstance.approve(ERC20AtomicSwapper.address, erc20Amount, { from: swapA });
-        let initiateTx = await swapInstance.initiate(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, erc20Amount, bep2Amount, { from: swapA });
+        let initiateTx = await swapInstance.hashTimerLockedTransfer(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, erc20Amount, bep2Amount, { from: swapA });
         //SwapInit event should be emitted
-        truffleAssert.eventEmitted(initiateTx, 'SwapInit', (ev) => {
+        truffleAssert.eventEmitted(initiateTx, 'HTLTInit', (ev) => {
             return ev._msgSender === swapA &&
                 ev._receiverAddr === swapB &&
                 ev._bep2Addr === bep2Addr &&
@@ -188,8 +188,8 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         });
         console.log("initiateTx gasUsed: ", initiateTx.receipt.gasUsed);
 
-        initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, false);
+        hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, false);
         var claimable = (await swapInstance.claimable.call(secretHashLock)).valueOf();
         assert.equal(claimable, true);
         var refundable = (await swapInstance.refundable.call(secretHashLock)).valueOf();
@@ -211,10 +211,10 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         assert.equal(Number(balanceOfSwapB.toString()), 0);
 
         // Anyone can call refund and the token will always been refunded to swapA address
-        let refundTx = await swapInstance.refund(secretHashLock, { from: accounts[6] });
+        let refundTx = await swapInstance.refundHashTimerLockedTransfer(secretHashLock, { from: accounts[6] });
 
         //SwapExpire n event should be emitted
-        truffleAssert.eventEmitted(refundTx, 'SwapExpire', (ev) => {
+        truffleAssert.eventEmitted(refundTx, 'HTLTExpire', (ev) => {
             return ev._msgSender === accounts[6] && ev._swapSender === swapA && ev._secretHashLock === secretHashLock;
         });
         console.log("refundTx gasUsed: ", refundTx.receipt.gasUsed);

--- a/ethereum/test/ERC20AtomicSwapTest.js
+++ b/ethereum/test/ERC20AtomicSwapTest.js
@@ -46,9 +46,6 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         const swapInstance = await ERC20AtomicSwapper.deployed();
         const erc20Address = await swapInstance.ERC20ContractAddr.call();
         assert.equal(erc20Address, BNBToken.address, "swap contract should have erc20 contract address");
-
-        const index = await swapInstance.index.call();
-        assert.equal(index, 0, "swap index initial value should be 0");
     });
     it('Test transfer, approve and transferFrom for BNB token', async () => {
         const bnbInstance = await BNBToken.deployed();
@@ -113,41 +110,20 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
             return ev._msgSender === swapA &&
                 ev._receiverAddr === swapB &&
                 ev._bep2Addr === bep2Addr &&
-                Number(ev._index.toString()) === 0 &&
                 ev._secretHashLock === secretHashLock &&
                 Number(ev._timestamp.toString()) === timestamp &&
-                Number(ev._erc20Amount.toString()) === erc20Amount &&
+                Number(ev._outAmount.toString()) === erc20Amount &&
                 Number(ev._bep2Amount.toString()) === bep2Amount;
         });
-
-        //Verify swap index
-        const index = await swapInstance.index.call();
-        assert.equal(index, 1, "swap index initial value should be 1");
 
         // Verify if the swapped ERC20 token has been transferred to contract address
         var balanceOfSwapContract = await bnbInstance.balanceOf.call(ERC20AtomicSwapper.address);
         assert.equal(Number(balanceOfSwapContract.toString()), erc20Amount);
 
         // querySwapByHashLock
-        var swap = (await swapInstance.querySwapByHashLock.call(secretHashLock)).valueOf();
+        var swap = (await swapInstance.queryOpenSwap.call(secretHashLock)).valueOf();
         assert.equal(timestamp, swap._timestamp);
-        assert.equal(0x0, swap._secretKey);
-        assert.equal(erc20Amount, swap._erc20Amount);
-        assert.equal(bep2Amount, swap._bep2Amount);
         assert.equal(swapA, swap._sender);
-        assert.equal(bep2Addr, swap._bep2Addr);
-        // swap status should be OPEN 1
-        assert.equal(1, swap._status);
-        //querySwapByIndex
-        swap = (await swapInstance.querySwapByIndex.call(0)).valueOf();
-        assert.equal(secretHashLock, swap._secretHashLock);
-        assert.equal(timestamp, swap._timestamp);
-        assert.equal(0x0, swap._secretKey);
-        assert.equal(erc20Amount, swap._erc20Amount);
-        assert.equal(bep2Amount, swap._bep2Amount);
-        assert.equal(swapA, swap._sender);
-        assert.equal(bep2Addr, swap._bep2Addr);
-        assert.equal(1, swap._status);
 
         initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
         assert.equal(initializable, false);
@@ -165,11 +141,6 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         truffleAssert.eventEmitted(claimTx, 'SwapComplete', (ev) => {
             return ev._msgSender === accounts[6] && ev._receiverAddr === swapB && ev._secretHashLock === secretHashLock && ev._secretKey === secretKey;
         });
-
-        swap = (await swapInstance.querySwapByHashLock.call(secretHashLock)).valueOf();
-        // swap status should be COMPLETED 2
-        assert.equal(2, swap._status);
-        assert.equal(secretKey, swap._secretKey);
 
         balanceOfSwapB = await bnbInstance.balanceOf.call(swapB);
         assert.equal(Number(balanceOfSwapB.toString()), erc20Amount);
@@ -208,15 +179,11 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
             return ev._msgSender === swapA &&
                 ev._receiverAddr === swapB &&
                 ev._bep2Addr === bep2Addr &&
-                Number(ev._index.toString()) === 1 &&
                 ev._secretHashLock === secretHashLock &&
                 Number(ev._timestamp.toString()) === timestamp &&
-                Number(ev._erc20Amount.toString()) === erc20Amount &&
+                Number(ev._outAmount.toString()) === erc20Amount &&
                 Number(ev._bep2Amount.toString()) === bep2Amount;
         });
-
-        const index = await swapInstance.index.call();
-        assert.equal(index, 2, "swap index initial value should be 2");
 
         initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
         assert.equal(initializable, false);
@@ -247,10 +214,6 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         truffleAssert.eventEmitted(refundTx, 'SwapExpire', (ev) => {
             return ev._msgSender === accounts[6] && ev._swapSender === swapA && ev._secretHashLock === secretHashLock;
         });
-
-        // swap status should be EXPIRED 3
-        const swap = (await swapInstance.querySwapByHashLock.call(secretHashLock)).valueOf();
-        assert.equal(3, swap._status);
 
         balanceOfSwapB = await bnbInstance.balanceOf.call(swapB);
         assert.equal(Number(balanceOfSwapB.toString()), 0);

--- a/ethereum/test/ERC20AtomicSwapTest.js
+++ b/ethereum/test/ERC20AtomicSwapTest.js
@@ -115,6 +115,7 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
                 Number(ev._outAmount.toString()) === erc20Amount &&
                 Number(ev._bep2Amount.toString()) === bep2Amount;
         });
+        console.log("initiateTx gasUsed: ", initiateTx.receipt.gasUsed);
 
         // Verify if the swapped ERC20 token has been transferred to contract address
         var balanceOfSwapContract = await bnbInstance.balanceOf.call(ERC20AtomicSwapper.address);
@@ -141,6 +142,7 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         truffleAssert.eventEmitted(claimTx, 'SwapComplete', (ev) => {
             return ev._msgSender === accounts[6] && ev._receiverAddr === swapB && ev._secretHashLock === secretHashLock && ev._secretKey === secretKey;
         });
+        console.log("claimTx gasUsed: ", claimTx.receipt.gasUsed);
 
         balanceOfSwapB = await bnbInstance.balanceOf.call(swapB);
         assert.equal(Number(balanceOfSwapB.toString()), erc20Amount);
@@ -184,6 +186,7 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
                 Number(ev._outAmount.toString()) === erc20Amount &&
                 Number(ev._bep2Amount.toString()) === bep2Amount;
         });
+        console.log("initiateTx gasUsed: ", initiateTx.receipt.gasUsed);
 
         initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
         assert.equal(initializable, false);
@@ -214,6 +217,7 @@ contract('Verify BNBToken and ERC20AtomicSwapper', (accounts) => {
         truffleAssert.eventEmitted(refundTx, 'SwapExpire', (ev) => {
             return ev._msgSender === accounts[6] && ev._swapSender === swapA && ev._secretHashLock === secretHashLock;
         });
+        console.log("refundTx gasUsed: ", refundTx.receipt.gasUsed);
 
         balanceOfSwapB = await bnbInstance.balanceOf.call(swapB);
         assert.equal(Number(balanceOfSwapB.toString()), 0);

--- a/ethereum/test/ETHAtomicSwapTest.js
+++ b/ethereum/test/ETHAtomicSwapTest.js
@@ -79,6 +79,7 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         const gasUsed = initiateTx.receipt.gasUsed;
         const tx = await web3.eth.getTransaction(initiateTx.tx);
         const txFee = gasUsed * tx.gasPrice;
+        console.log("initiateTx gasUsed: ", initiateTx.receipt.gasUsed);
 
         var balanceOfSwapA = await web3.eth.getBalance(swapA);
         assert.equal(balanceOfSwapA.toString(), new Big(initialbalanceOfSwapA).minus(ETHCoin).minus(txFee).toString());
@@ -91,6 +92,7 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         truffleAssert.eventEmitted(claimTx, 'SwapComplete', (ev) => {
             return ev._msgSender === accounts[6] && ev._receiverAddr === swapB && ev._secretHashLock === secretHashLock && ev._secretKey === secretKey;
         });
+        console.log("claimTx gasUsed: ", claimTx.receipt.gasUsed);
 
         balanceOfSwapB = await web3.eth.getBalance(swapB);
         assert.equal(balanceOfSwapB.toString(), new Big(initialbalanceOfSwapB).plus(ETHCoin).toString());
@@ -139,6 +141,7 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         const gasUsed = initiateTx.receipt.gasUsed;
         const tx = await web3.eth.getTransaction(initiateTx.tx);
         const txFee = gasUsed * tx.gasPrice;
+        console.log("initiateTx gasUsed: ", initiateTx.receipt.gasUsed);
 
         initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
         assert.equal(initializable, false);
@@ -168,6 +171,7 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         truffleAssert.eventEmitted(refundTx, 'SwapExpire', (ev) => {
             return ev._msgSender === accounts[6] && ev._swapSender === swapA && ev._secretHashLock === secretHashLock;
         });
+        console.log("refundTx gasUsed: ", refundTx.receipt.gasUsed);
 
         var balanceOfSwapB = await web3.eth.getBalance(swapB);
         assert.equal(initialbalanceOfSwapB, balanceOfSwapB);

--- a/ethereum/test/ETHAtomicSwapTest.js
+++ b/ethereum/test/ETHAtomicSwapTest.js
@@ -42,15 +42,15 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         const ETHCoin = 100000000;
         const bep2Amount = 100000000;
 
-        var initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, true);
+        var hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, true);
 
         const initialbalanceOfSwapA = await web3.eth.getBalance(swapA);
         const initialbalanceOfSwapB = await web3.eth.getBalance(swapB);
 
-        let initiateTx = await swapInstance.initiate(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, bep2Amount, { from: swapA , value: ETHCoin});
+        let initiateTx = await swapInstance.hashTimerLockedTransfer(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, bep2Amount, { from: swapA , value: ETHCoin});
         //SwapInit event should be emitted
-        truffleAssert.eventEmitted(initiateTx, 'SwapInit', (ev) => {
+        truffleAssert.eventEmitted(initiateTx, 'HTLTInit', (ev) => {
             return ev._msgSender === swapA &&
                 ev._receiverAddr === swapB &&
                 ev._bep2Addr === bep2Addr &&
@@ -69,8 +69,8 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         assert.equal(timestamp, swap._timestamp);
         assert.equal(ETHCoin, swap._outAmount);
 
-        initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, false);
+        hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, false);
         var claimable = (await swapInstance.claimable.call(secretHashLock)).valueOf();
         assert.equal(claimable, true);
         var refundable = (await swapInstance.refundable.call(secretHashLock)).valueOf();
@@ -87,9 +87,9 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         assert.equal(balanceOfSwapB, initialbalanceOfSwapB);
 
         // Anyone can call claim and the token will be paid to swapB address
-        let claimTx = await swapInstance.claim(secretHashLock, secretKey, { from: accounts[6] });
+        let claimTx = await swapInstance.claimHashTimerLockedTransfer(secretHashLock, secretKey, { from: accounts[6] });
         //SwapComplete n event should be emitted
-        truffleAssert.eventEmitted(claimTx, 'SwapComplete', (ev) => {
+        truffleAssert.eventEmitted(claimTx, 'HTLTComplete', (ev) => {
             return ev._msgSender === accounts[6] && ev._receiverAddr === swapB && ev._secretHashLock === secretHashLock && ev._secretKey === secretKey;
         });
         console.log("claimTx gasUsed: ", claimTx.receipt.gasUsed);
@@ -120,15 +120,15 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         const ETHCoin = 100000000;
         const bep2Amount = 100000000;
 
-        var initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, true);
+        var hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, true);
 
         const initialbalanceOfSwapA = await web3.eth.getBalance(swapA);
         const initialbalanceOfSwapB = await web3.eth.getBalance(swapB);
 
-        let initiateTx = await swapInstance.initiate(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, bep2Amount, { from: swapA , value: ETHCoin});
+        let initiateTx = await swapInstance.hashTimerLockedTransfer(secretHashLock, timestamp, timelock, receiverAddr, bep2Addr, bep2Amount, { from: swapA , value: ETHCoin});
         //SwapInit event should be emitted
-        truffleAssert.eventEmitted(initiateTx, 'SwapInit', (ev) => {
+        truffleAssert.eventEmitted(initiateTx, 'HTLTInit', (ev) => {
             return ev._msgSender === swapA &&
                 ev._receiverAddr === swapB &&
                 ev._bep2Addr === bep2Addr &&
@@ -143,8 +143,8 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         const txFee = gasUsed * tx.gasPrice;
         console.log("initiateTx gasUsed: ", initiateTx.receipt.gasUsed);
 
-        initializable = (await swapInstance.initializable.call(secretHashLock)).valueOf();
-        assert.equal(initializable, false);
+        hashLockable = (await swapInstance.hashLockable.call(secretHashLock)).valueOf();
+        assert.equal(hashLockable, false);
         var claimable = (await swapInstance.claimable.call(secretHashLock)).valueOf();
         assert.equal(claimable, true);
         var refundable = (await swapInstance.refundable.call(secretHashLock)).valueOf();
@@ -165,10 +165,10 @@ contract('Verify ETHAtomicSwapper', (accounts) => {
         assert.equal(balanceOfSwapABeforeRefund.toString(), new Big(initialbalanceOfSwapA).minus(txFee).minus(ETHCoin).toString());
 
         // Anyone can call refund and the token will always been refunded to swapA address
-        let refundTx = await swapInstance.refund(secretHashLock, { from: accounts[6] });
+        let refundTx = await swapInstance.refundHashTimerLockedTransfer(secretHashLock, { from: accounts[6] });
 
         //SwapExpire n event should be emitted
-        truffleAssert.eventEmitted(refundTx, 'SwapExpire', (ev) => {
+        truffleAssert.eventEmitted(refundTx, 'HTLTExpire', (ev) => {
             return ev._msgSender === accounts[6] && ev._swapSender === swapA && ev._secretHashLock === secretHashLock;
         });
         console.log("refundTx gasUsed: ", refundTx.receipt.gasUsed);


### PR DESCRIPTION
**ERC20 swap** gas consumption

Simulation result:

|          |    initiate   |   claim   |  refund  |
|----------| --------------| ----------| -------- |
| original |    248814     |   73270   |   34035  |
| optimize |    162710     |   47089   |   37516  |

Running result on **Ropsten testnet**:

|          |    initiate   |   claim   |  refund  |
|----------| --------------| ----------| -------- |
| **original** |    233313     |   72459   |   48307  |
| **optimize** |    162127     |   36405   |   34336  |


**ETH swap** gas consumption

Simulation result:

|          |    initiate   |   claim   |  refund  |
|----------| --------------| ----------| -------- |
| original |    224492     |   64408   |   40214  |
| optimize |    138299     |   35202   |   33127  |

Running result on **Ropsten testnet**:

|          |    initiate   |   claim   |  refund  |
|----------| --------------| ----------| -------- |
| **original** |    209402     |   88848   |   48307  |
| **optimize** |    138127     |   44674   |   30106  |

According to the running result on **Ropsten testnet**, the optimization can significantly decrease the gas consumption. The simulation result is not accurate.

The most significant impact for deputy is that deputy has to query secretKey by event log instead of call query interface.