### PR TITLE
R4R: Add swapID, hash of randomNumberHash and msg.sender

### DIFF
--- a/ethereum/contracts/ERC20AtomicSwapper.sol
+++ b/ethereum/contracts/ERC20AtomicSwapper.sol
@@ -14,6 +14,7 @@ contract ERC20AtomicSwapper {
     struct Swap {
         uint256 outAmount;
         uint256 expireHeight;
+        bytes32 randomNumberHash;
         uint64  timestamp;
         address sender;
         address receiverAddr;
@@ -27,9 +28,9 @@ contract ERC20AtomicSwapper {
     }
 
     // Events
-    event HTLT(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _randomNumberHash, uint64 _timestamp, bytes20 _bep2Addr, uint256 _expireHeight, uint256 _outAmount, uint256 _bep2Amount);
-    event Refunded(address indexed _msgSender, address indexed _swapSender, bytes32 indexed _randomNumberHash);
-    event Claimed(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _randomNumberHash, bytes32 _randomNumber);
+    event HTLT(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _swapID, bytes32 _randomNumberHash, uint64 _timestamp, bytes20 _bep2Addr, uint256 _expireHeight, uint256 _outAmount, uint256 _bep2Amount);
+    event Refunded(address indexed _msgSender, address indexed _swapSender, bytes32 indexed _swapID, bytes32 _randomNumberHash);
+    event Claimed(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _swapID, bytes32 _randomNumberHash, bytes32 _randomNumber);
 
     // Storage
     mapping (bytes32 => Swap) private swaps;
@@ -37,33 +38,27 @@ contract ERC20AtomicSwapper {
 
     address public ERC20ContractAddr;
 
-    /// @notice Throws if the swap is not invalid (i.e. has already been used)
-    modifier onlyInvalidSwaps(bytes32 _randomNumberHash) {
-        require(swapStates[_randomNumberHash] == States.INVALID, "swap is opened previously");
-        _;
-    }
-
     /// @notice Throws if the swap is not open.
-    modifier onlyOpenSwaps(bytes32 _randomNumberHash) {
-        require(swapStates[_randomNumberHash] == States.OPEN, "swap is not opened");
+    modifier onlyOpenSwaps(bytes32 _swapID) {
+        require(swapStates[_swapID] == States.OPEN, "swap is not opened");
         _;
     }
 
     /// @notice Throws if the swap is already expired.
-    modifier onlyAfterExpireHeight(bytes32 _randomNumberHash) {
-        require(block.number >= swaps[_randomNumberHash].expireHeight, "swap is not expired");
+    modifier onlyAfterExpireHeight(bytes32 _swapID) {
+        require(block.number >= swaps[_swapID].expireHeight, "swap is not expired");
         _;
     }
 
     /// @notice Throws if the expireHeight is reached
-    modifier onlyBeforeExpireHeight(bytes32 _randomNumberHash) {
-        require(block.number < swaps[_randomNumberHash].expireHeight, "swap is already expired");
+    modifier onlyBeforeExpireHeight(bytes32 _swapID) {
+        require(block.number < swaps[_swapID].expireHeight, "swap is already expired");
         _;
     }
 
     /// @notice Throws if the random number is not valid.
-    modifier onlyWithRandomNumber(bytes32 _randomNumberHash, bytes32 _randomNumber) {
-        require(_randomNumberHash == calRandomNumberHash(_randomNumber, swaps[_randomNumberHash].timestamp), "invalid randomNumber");
+    modifier onlyWithRandomNumber(bytes32 _swapID, bytes32 _randomNumber) {
+        require(swaps[_swapID].randomNumberHash == sha256(abi.encodePacked(_randomNumber, swaps[_swapID].timestamp)), "invalid randomNumber");
         _;
     }
 
@@ -72,7 +67,7 @@ contract ERC20AtomicSwapper {
         ERC20ContractAddr = _erc20Contract;
     }
 
-    /// @notice hashTimerLockedTransfer locks asset to contract address and create an atomic swap.
+    /// @notice htlt locks asset to contract address and create an atomic swap.
     ///
     /// @param _randomNumberHash The hash of the random number and timestamp
     /// @param _timestamp Counted by second
@@ -89,8 +84,10 @@ contract ERC20AtomicSwapper {
         bytes20 _bep2Addr,
         uint256 _outAmount,
         uint256 _bep2Amount
-    ) external onlyInvalidSwaps(_randomNumberHash) returns (bool) {
+    ) external returns (bool) {
         require(_outAmount > 0, "_outAmount must be more than 0");
+        bytes32 swapID = sha256(abi.encodePacked(_randomNumberHash, msg.sender));
+        require(swapStates[swapID] == States.INVALID, "swap is opened previously");
         // Assume average block time interval is 10 second
         // The heightSpan period should be more than 10 minutes and less than one week
         require(_heightSpan >= 60 && _heightSpan <= 60480, "_heightSpan should be in [60, 60480]");
@@ -100,71 +97,75 @@ contract ERC20AtomicSwapper {
         Swap memory swap = Swap({
             outAmount: _outAmount,
             expireHeight: _heightSpan + block.number,
+            randomNumberHash: _randomNumberHash,
             timestamp: _timestamp,
             sender: msg.sender,
             receiverAddr: _receiverAddr
         });
 
-        swaps[_randomNumberHash] = swap;
-        swapStates[_randomNumberHash] = States.OPEN;
+        swaps[swapID] = swap;
+        swapStates[swapID] = States.OPEN;
 
         // Transfer ERC20 token to the swap contract
         require(ERC20(ERC20ContractAddr).transferFrom(msg.sender, address(this), _outAmount), "failed to transfer client asset to swap contract address");
 
         // Emit initialization event
-        emit HTLT(msg.sender, _receiverAddr, _randomNumberHash, _timestamp, _bep2Addr, swap.expireHeight, _outAmount, _bep2Amount);
+        emit HTLT(msg.sender, _receiverAddr, swapID, _randomNumberHash, _timestamp, _bep2Addr, swap.expireHeight, _outAmount, _bep2Amount);
         return true;
     }
 
     /// @notice claim claims the previously locked asset.
     ///
-    /// @param _randomNumberHash The hash of randomNumber and timestamp
+    /// @param _swapID The hash of randomNumberHash and swap creator
     /// @param _randomNumber The random number
-    function claim(bytes32 _randomNumberHash, bytes32 _randomNumber) external onlyOpenSwaps(_randomNumberHash) onlyBeforeExpireHeight(_randomNumberHash) onlyWithRandomNumber(_randomNumberHash, _randomNumber) returns (bool) {
+    function claim(bytes32 _swapID, bytes32 _randomNumber) external onlyOpenSwaps(_swapID) onlyBeforeExpireHeight(_swapID) onlyWithRandomNumber(_swapID, _randomNumber) returns (bool) {
         // Complete the swap.
-        swapStates[_randomNumberHash] = States.COMPLETED;
+        swapStates[_swapID] = States.COMPLETED;
 
-        address receiverAddr = swaps[_randomNumberHash].receiverAddr;
-        uint256 outAmount = swaps[_randomNumberHash].outAmount;
+        address receiverAddr = swaps[_swapID].receiverAddr;
+        uint256 outAmount = swaps[_swapID].outAmount;
+        bytes32 randomNumberHash = swaps[_swapID].randomNumberHash;
         // delete closed swap
-        delete swaps[_randomNumberHash];
+        delete swaps[_swapID];
 
         // Pay erc20 token to receiver
         require(ERC20(ERC20ContractAddr).transfer(receiverAddr, outAmount), "Failed to transfer locked asset to receiver");
 
         // Emit completion event
-        emit Claimed(msg.sender, receiverAddr, _randomNumberHash, _randomNumber);
+        emit Claimed(msg.sender, receiverAddr, _swapID, randomNumberHash, _randomNumber);
 
         return true;
     }
 
     /// @notice refund refunds the previously locked asset.
     ///
-    /// @param _randomNumberHash The hash of randomNumber and timestamp
-    function refund(bytes32 _randomNumberHash) external onlyOpenSwaps(_randomNumberHash) onlyAfterExpireHeight(_randomNumberHash) returns (bool) {
+    /// @param _swapID The hash of randomNumberHash and swap creator
+    function refund(bytes32 _swapID) external onlyOpenSwaps(_swapID) onlyAfterExpireHeight(_swapID) returns (bool) {
         // Expire the swap.
-        swapStates[_randomNumberHash] = States.EXPIRED;
+        swapStates[_swapID] = States.EXPIRED;
 
-        address swapSender = swaps[_randomNumberHash].sender;
-        uint256 outAmount = swaps[_randomNumberHash].outAmount;
+        address swapSender = swaps[_swapID].sender;
+        uint256 outAmount = swaps[_swapID].outAmount;
+        bytes32 randomNumberHash = swaps[_swapID].randomNumberHash;
         // delete closed swap
-        delete swaps[_randomNumberHash];
+        delete swaps[_swapID];
 
         // refund erc20 token to swap creator
         require(ERC20(ERC20ContractAddr).transfer(swapSender, outAmount), "Failed to transfer locked asset back to swap creator");
 
         // Emit expire event
-        emit Refunded(msg.sender, swapSender, _randomNumberHash);
+        emit Refunded(msg.sender, swapSender, _swapID, randomNumberHash);
 
         return true;
     }
 
     /// @notice query an atomic swap by randomNumberHash
     ///
-    /// @param _randomNumberHash The hash of randomNumber and timestamp
-    function queryOpenSwap(bytes32 _randomNumberHash) external view returns(uint64 _timestamp, uint256 _expireHeight, uint256 _outAmount, address _sender, address _receiver) {
-        Swap memory swap = swaps[_randomNumberHash];
+    /// @param _swapID The hash of randomNumberHash and swap creator
+    function queryOpenSwap(bytes32 _swapID) external view returns(bytes32 _randomNumberHash, uint64 _timestamp, uint256 _expireHeight, uint256 _outAmount, address _sender, address _receiver) {
+        Swap memory swap = swaps[_swapID];
         return (
+            swap.randomNumberHash,
             swap.timestamp,
             swap.expireHeight,
             swap.outAmount,
@@ -173,32 +174,32 @@ contract ERC20AtomicSwapper {
         );
     }
 
-    /// @notice Checks whether a _randomNumberHash can be used to create a hash lock or not.
+    /// @notice Checks whether a swap with specified swapID exist
     ///
-    /// @param _randomNumberHash The hash of randomNumber and timestamp
-    function hashLockable(bytes32 _randomNumberHash) external view returns (bool) {
-        return (swapStates[_randomNumberHash] == States.INVALID);
+    /// @param _swapID The hash of randomNumberHash and swap creator
+    function swapExistence(bytes32 _swapID) external view returns (bool) {
+        return (swapStates[_swapID] == States.INVALID);
     }
 
     /// @notice Checks whether a swap is refundable or not.
     ///
-    /// @param _randomNumberHash The hash of randomNumber and timestamp
-    function refundable(bytes32 _randomNumberHash) external view returns (bool) {
-        return (block.number >= swaps[_randomNumberHash].expireHeight && swapStates[_randomNumberHash] == States.OPEN);
+    /// @param _swapID The hash of randomNumberHash and swap creator
+    function refundable(bytes32 _swapID) external view returns (bool) {
+        return (block.number >= swaps[_swapID].expireHeight && swapStates[_swapID] == States.OPEN);
     }
 
     /// @notice Checks whether a swap is claimable or not.
     ///
-    /// @param _randomNumberHash The hash of randomNumber and timestamp
-    function claimable(bytes32 _randomNumberHash) external view returns (bool) {
-        return (block.number < swaps[_randomNumberHash].expireHeight && swapStates[_randomNumberHash] == States.OPEN);
+    /// @param _swapID The hash of randomNumberHash and swap creator
+    function claimable(bytes32 _swapID) external view returns (bool) {
+        return (block.number < swaps[_swapID].expireHeight && swapStates[_swapID] == States.OPEN);
     }
 
-    /// @notice Calculate the randomNumberHash from randomNumber and timestamp
+    /// @notice Calculate the swapID from randomNumberHash and swapCreator
     ///
-    /// @param _randomNumber The random number.
-    /// @param _timestamp The timestamp.
-    function calRandomNumberHash(bytes32 _randomNumber, uint64 _timestamp) public pure returns (bytes32) {
-        return sha256(abi.encodePacked(_randomNumber, _timestamp));
+    /// @param _randomNumberHash The hash of random number and timestamp.
+    /// @param _swapCreator The creator of swap.
+    function calSwapID(bytes32 _randomNumberHash, address _swapCreator) public pure returns (bytes32) {
+        return sha256(abi.encodePacked(_randomNumberHash, _swapCreator));
     }
 }

--- a/ethereum/contracts/ETHAtomicSwapper.sol
+++ b/ethereum/contracts/ETHAtomicSwapper.sol
@@ -8,7 +8,7 @@ contract ETHAtomicSwapper {
         bytes32 randomNumberHash;
         uint64  timestamp;
         address payable sender;
-        address payable receiverAddr;
+        address payable recipientAddr;
     }
 
     enum States {
@@ -19,9 +19,9 @@ contract ETHAtomicSwapper {
     }
 
     // Events
-    event HTLT(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _swapID, bytes32 _randomNumberHash, uint64 _timestamp, bytes20 _bep2Addr, uint256 _expireHeight, uint256 _outAmount, uint256 _bep2Amount);
+    event HTLT(address indexed _msgSender, address indexed _recipientAddr, bytes32 indexed _swapID, bytes32 _randomNumberHash, uint64 _timestamp, bytes20 _bep2Addr, uint256 _expireHeight, uint256 _outAmount, uint256 _bep2Amount);
     event Refunded(address indexed _msgSender, address indexed _swapSender, bytes32 indexed _swapID, bytes32 _randomNumberHash);
-    event Claimed(address indexed _msgSender, address indexed _receiverAddr, bytes32 indexed _swapID, bytes32 _randomNumberHash, bytes32 _randomNumber);
+    event Claimed(address indexed _msgSender, address indexed _recipientAddr, bytes32 indexed _swapID, bytes32 _randomNumberHash, bytes32 _randomNumber);
 
     // Storage
     mapping (bytes32 => Swap) private swaps;
@@ -62,24 +62,24 @@ contract ETHAtomicSwapper {
     /// @param _randomNumberHash The hash of the random number and timestamp
     /// @param _timestamp Counted by second
     /// @param _heightSpan The number of blocks to wait before the asset can be returned to sender
-    /// @param _receiverAddr The ethereum address of the swap counterpart.
-    /// @param _bep2Addr The receiver address on Binance Chain
+    /// @param _recipientAddr The ethereum address of the swap counterpart.
+    /// @param _bep2Addr The recipient address on Binance Chain
     /// @param _bep2Amount BEP2 asset to swap in.
     function htlt(
         bytes32 _randomNumberHash,
         uint64  _timestamp,
         uint256 _heightSpan,
-        address payable _receiverAddr,
+        address payable _recipientAddr,
         bytes20 _bep2Addr,
         uint256 _bep2Amount
     ) external payable returns (bool) {
         require(msg.value > 0, "msg.value must be more than 0");
-        bytes32 swapID = sha256(abi.encodePacked(_randomNumberHash, msg.sender));
+        bytes32 swapID = sha256(abi.encodePacked(_randomNumberHash, msg.sender, _recipientAddr));
         require(swapStates[swapID] == States.INVALID, "swap is opened previously");
         // Assume average block time interval is 10 second
         // The heightSpan period should be more than 10 minutes and less than one week
         require(_heightSpan >= 60 && _heightSpan <= 60480, "_heightSpan should be in [60, 60480]");
-        require(_receiverAddr != address(0), "_receiverAddr should not be zero");
+        require(_recipientAddr != address(0), "_recipientAddr should not be zero");
         require(_timestamp > now -7200 && _timestamp < now + 3600, "The timestamp should not be one hour ahead or two hour behind current time");
         // Store the details of the swap.
         Swap memory swap = Swap({
@@ -88,14 +88,14 @@ contract ETHAtomicSwapper {
             randomNumberHash: _randomNumberHash,
             timestamp: _timestamp,
             sender: msg.sender,
-            receiverAddr: _receiverAddr
+            recipientAddr: _recipientAddr
             });
 
         swaps[swapID] = swap;
         swapStates[swapID] = States.OPEN;
 
         // Emit initialization event
-        emit HTLT(msg.sender, _receiverAddr, swapID, _randomNumberHash, _timestamp, _bep2Addr, swap.expireHeight, msg.value, _bep2Amount);
+        emit HTLT(msg.sender, _recipientAddr, swapID, _randomNumberHash, _timestamp, _bep2Addr, swap.expireHeight, msg.value, _bep2Amount);
         return true;
     }
 
@@ -107,17 +107,17 @@ contract ETHAtomicSwapper {
         // Complete the swap.
         swapStates[_swapID] = States.COMPLETED;
 
-        address payable receiverAddr = swaps[_swapID].receiverAddr;
+        address payable recipientAddr = swaps[_swapID].recipientAddr;
         uint256 outAmount = swaps[_swapID].outAmount;
         bytes32 randomNumberHash = swaps[_swapID].randomNumberHash;
         // delete closed swap
         delete swaps[_swapID];
 
-        // Pay eth coin to receiver
-        receiverAddr.transfer(outAmount);
+        // Pay eth coin to recipient
+        recipientAddr.transfer(outAmount);
 
         // Emit completion event
-        emit Claimed(msg.sender, receiverAddr, _swapID, randomNumberHash, _randomNumber);
+        emit Claimed(msg.sender, recipientAddr, _swapID, randomNumberHash, _randomNumber);
 
         return true;
     }
@@ -147,7 +147,7 @@ contract ETHAtomicSwapper {
     /// @notice query an atomic swap by randomNumberHash
     ///
     /// @param _swapID The hash of randomNumberHash and swap creator
-    function queryOpenSwap(bytes32 _swapID) external view returns(bytes32 _randomNumberHash, uint64 _timestamp, uint256 _expireHeight, uint256 _outAmount, address _sender, address _receiver) {
+    function queryOpenSwap(bytes32 _swapID) external view returns(bytes32 _randomNumberHash, uint64 _timestamp, uint256 _expireHeight, uint256 _outAmount, address _sender, address _recipient) {
         Swap memory swap = swaps[_swapID];
         return (
             swap.randomNumberHash,
@@ -155,7 +155,7 @@ contract ETHAtomicSwapper {
             swap.expireHeight,
             swap.outAmount,
             swap.sender,
-            swap.receiverAddr
+            swap.recipientAddr
         );
     }
 
@@ -184,7 +184,7 @@ contract ETHAtomicSwapper {
     ///
     /// @param _randomNumberHash The hash of random number and timestamp.
     /// @param _swapCreator The creator of swap.
-    function calSwapID(bytes32 _randomNumberHash, address _swapCreator) public pure returns (bytes32) {
-        return sha256(abi.encodePacked(_randomNumberHash, _swapCreator));
+    function calSwapID(bytes32 _randomNumberHash, address _swapCreator, address _recipientAddr) public pure returns (bytes32) {
+        return sha256(abi.encodePacked(_randomNumberHash, _swapCreator, _recipientAddr));
     }
 }


### PR DESCRIPTION
**ERC20 swap** gas consumption

Simulation result:

|          |    htlt   |   claim   |  refund  |
|----------| --------------| ----------| -------- |
| original |    162710     |   47089   |   37516  |
| randomNumberHash+sender |    184402     |   49859   |   40147  |
| randomNumberHash+sender+recipient |    184565     |   49827   |   40147  |

**ETH swap** gas consumption

Simulation result:

|          |    htlt   |   claim   |  refund  |
|----------| --------------| ----------| -------- |
| original |    138299     |   35202   |   33127  |
| randomNumberHash+sender |    160030     |   37950   |   35724  |
| andomNumberHash+sender+recipient |    160107     |   37950   |   35724  |